### PR TITLE
Remove mdtp_sans_serif translation

### DIFF
--- a/library/src/main/res/values-pt-rBR/strings.xml
+++ b/library/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="mdtp_sans_serif">sans-serif</string>
     <string name="mdtp_cancel">@android:string/cancel</string>
     <string name="mdtp_ok">@android:string/ok</string>
     <string name="mdtp_done_label">Feito</string>


### PR DESCRIPTION
Translators should not translate `translatable="false"` strings...