### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Material Date and Time Picker with Range Selection
 
 Credit to the original amazing material date picker library by wdullaer - https://github.com/wdullaer/MaterialDateTimePicker
 
-##Adding to your project
+## Adding to your project
 
 Add the jcenter repository information in your build.gradle file like this
 ```java
@@ -25,17 +25,17 @@ dependencies {
 ```
 
 
-##Update
+## Update
 --added highlighted range selection method
 --added portuguese translation
 --add end time selection in TimePicker
 
-##Date Selection
+## Date Selection
 
 ![FROM](/screenshots/2.png?raw=true)
 ![TO](/screenshots/1.png?raw=true)
 
-##Time Selection
+## Time Selection
 
 ![FROM](/screenshots/3.png?raw=true)
 ![TO](/screenshots/4.png?raw=true)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
